### PR TITLE
Add automatic backup translations

### DIFF
--- a/uhabits-android/src/main/res/values-af-rZA/strings.xml
+++ b/uhabits-android/src/main/res/values-af-rZA/strings.xml
@@ -53,4 +53,5 @@
     <string name="public_backup_frequency_7d">7 dae</string>
     <string name="public_backup_frequency_14d">14 dae</string>
     <string name="public_backup_frequency_1m">1 maand</string>
+    <string name="automatic_backup">Outomatiese rugsteun</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ar-rSA/strings.xml
+++ b/uhabits-android/src/main/res/values-ar-rSA/strings.xml
@@ -257,4 +257,5 @@
     <string name="public_backup_frequency_7d">7 أيام</string>
     <string name="public_backup_frequency_14d">14 يومًا</string>
     <string name="public_backup_frequency_1m">1 شهر</string>
+    <string name="automatic_backup">النسخ الاحتياطي التلقائي</string>
 </resources>

--- a/uhabits-android/src/main/res/values-bg-rBG/strings.xml
+++ b/uhabits-android/src/main/res/values-bg-rBG/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 дни</string>
     <string name="public_backup_frequency_14d">14 дни</string>
     <string name="public_backup_frequency_1m">1 месец</string>
+    <string name="automatic_backup">Автоматично архивиране</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ca-rES/strings.xml
+++ b/uhabits-android/src/main/res/values-ca-rES/strings.xml
@@ -224,4 +224,5 @@
     <string name="public_backup_frequency_7d">7 dies</string>
     <string name="public_backup_frequency_14d">14 dies</string>
     <string name="public_backup_frequency_1m">1 mes</string>
+    <string name="automatic_backup">Còpia de seguretat automàtica</string>
 </resources>

--- a/uhabits-android/src/main/res/values-cs-rCZ/strings.xml
+++ b/uhabits-android/src/main/res/values-cs-rCZ/strings.xml
@@ -245,4 +245,5 @@
     <string name="public_backup_frequency_7d">7 dní</string>
     <string name="public_backup_frequency_14d">14 dní</string>
     <string name="public_backup_frequency_1m">1 měsíc</string>
+    <string name="automatic_backup">Automatická záloha</string>
 </resources>

--- a/uhabits-android/src/main/res/values-da-rDK/strings.xml
+++ b/uhabits-android/src/main/res/values-da-rDK/strings.xml
@@ -236,4 +236,5 @@
     <string name="public_backup_frequency_7d">7 dage</string>
     <string name="public_backup_frequency_14d">14 dage</string>
     <string name="public_backup_frequency_1m">1 måned</string>
+    <string name="automatic_backup">Automatisk sikkerhedskopi</string>
 </resources>

--- a/uhabits-android/src/main/res/values-de-rDE/strings.xml
+++ b/uhabits-android/src/main/res/values-de-rDE/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 Tage</string>
     <string name="public_backup_frequency_14d">14 Tage</string>
     <string name="public_backup_frequency_1m">1 Monat</string>
+    <string name="automatic_backup">Automatische Sicherung</string>
 </resources>

--- a/uhabits-android/src/main/res/values-el-rGR/strings.xml
+++ b/uhabits-android/src/main/res/values-el-rGR/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 ημέρες</string>
     <string name="public_backup_frequency_14d">14 ημέρες</string>
     <string name="public_backup_frequency_1m">1 μήνα</string>
+    <string name="automatic_backup">Αυτόματο αντίγραφο ασφαλείας</string>
 </resources>

--- a/uhabits-android/src/main/res/values-eo-rUY/strings.xml
+++ b/uhabits-android/src/main/res/values-eo-rUY/strings.xml
@@ -166,4 +166,5 @@
     <string name="public_backup_frequency_7d">7 Tagoj</string>
     <string name="public_backup_frequency_14d">14 tagoj</string>
     <string name="public_backup_frequency_1m">1 monato</string>
+    <string name="automatic_backup">Aŭtomata sekurkopio</string>
 </resources>

--- a/uhabits-android/src/main/res/values-es-rES/strings.xml
+++ b/uhabits-android/src/main/res/values-es-rES/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 días</string>
     <string name="public_backup_frequency_14d">14 días</string>
     <string name="public_backup_frequency_1m">1 mes</string>
+    <string name="automatic_backup">Copia de seguridad automática</string>
 </resources>

--- a/uhabits-android/src/main/res/values-eu-rES/strings.xml
+++ b/uhabits-android/src/main/res/values-eu-rES/strings.xml
@@ -231,4 +231,5 @@
     <string name="public_backup_frequency_7d">7 egun</string>
     <string name="public_backup_frequency_14d">14 egun</string>
     <string name="public_backup_frequency_1m">Hilabete 1</string>
+    <string name="automatic_backup">Babeskopia automatikoa</string>
 </resources>

--- a/uhabits-android/src/main/res/values-fa-rIR/strings.xml
+++ b/uhabits-android/src/main/res/values-fa-rIR/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 روز</string>
     <string name="public_backup_frequency_14d">14 روز</string>
     <string name="public_backup_frequency_1m">1 ماه</string>
+    <string name="automatic_backup">پشتیبان خودکار</string>
 </resources>

--- a/uhabits-android/src/main/res/values-fi-rFI/strings.xml
+++ b/uhabits-android/src/main/res/values-fi-rFI/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 päivää</string>
     <string name="public_backup_frequency_14d">14 päivää</string>
     <string name="public_backup_frequency_1m">1 kuukausi</string>
+    <string name="automatic_backup">Automaattinen varmuuskopio</string>
 </resources>

--- a/uhabits-android/src/main/res/values-fr-rFR/strings.xml
+++ b/uhabits-android/src/main/res/values-fr-rFR/strings.xml
@@ -234,4 +234,5 @@ Combien de pages avez-vous lu ?</string>
     <string name="public_backup_frequency_7d">7 jours</string>
     <string name="public_backup_frequency_14d">14 jours</string>
     <string name="public_backup_frequency_1m">1 mois</string>
+    <string name="automatic_backup">Sauvegarde automatique</string>
 </resources>

--- a/uhabits-android/src/main/res/values-gu-rIN/strings.xml
+++ b/uhabits-android/src/main/res/values-gu-rIN/strings.xml
@@ -32,4 +32,5 @@
     <string name="public_backup_frequency_7d">7 દિવસ</string>
     <string name="public_backup_frequency_14d">14 દિવસ</string>
     <string name="public_backup_frequency_1m">1 મહિનો</string>
+    <string name="automatic_backup">સ્વચાલિત બેકઅપ</string>
 </resources>

--- a/uhabits-android/src/main/res/values-hi-rIN/strings.xml
+++ b/uhabits-android/src/main/res/values-hi-rIN/strings.xml
@@ -262,4 +262,5 @@
     <string name="public_backup_frequency_7d">7 दिन</string>
     <string name="public_backup_frequency_14d">14 दिन</string>
     <string name="public_backup_frequency_1m">1 महीना</string>
+    <string name="automatic_backup">स्वत: बैकअप</string>
 </resources>

--- a/uhabits-android/src/main/res/values-hr-rHR/strings.xml
+++ b/uhabits-android/src/main/res/values-hr-rHR/strings.xml
@@ -213,4 +213,5 @@
     <string name="public_backup_frequency_7d">7 dana</string>
     <string name="public_backup_frequency_14d">14 dana</string>
     <string name="public_backup_frequency_1m">1 mjesec</string>
+    <string name="automatic_backup">Automatska sigurnosna kopija</string>
 </resources>

--- a/uhabits-android/src/main/res/values-hu-rHU/strings.xml
+++ b/uhabits-android/src/main/res/values-hu-rHU/strings.xml
@@ -238,4 +238,5 @@
     <string name="public_backup_frequency_7d">7 nap</string>
     <string name="public_backup_frequency_14d">14 nap</string>
     <string name="public_backup_frequency_1m">1 hónap</string>
+    <string name="automatic_backup">Automatikus biztonsági mentés</string>
 </resources>

--- a/uhabits-android/src/main/res/values-hy-rAM/strings.xml
+++ b/uhabits-android/src/main/res/values-hy-rAM/strings.xml
@@ -97,4 +97,5 @@
     <string name="public_backup_frequency_7d">7 օր</string>
     <string name="public_backup_frequency_14d">14 օր</string>
     <string name="public_backup_frequency_1m">1 ամիս</string>
+    <string name="automatic_backup">Ավտոմատ կրկնօրինակում</string>
 </resources>

--- a/uhabits-android/src/main/res/values-in-rID/strings.xml
+++ b/uhabits-android/src/main/res/values-in-rID/strings.xml
@@ -236,4 +236,5 @@
     <string name="public_backup_frequency_7d">7 hari</string>
     <string name="public_backup_frequency_14d">14 hari</string>
     <string name="public_backup_frequency_1m">1 bulan</string>
+    <string name="automatic_backup">Cadangan Otomatis</string>
 </resources>

--- a/uhabits-android/src/main/res/values-is-rIS/strings.xml
+++ b/uhabits-android/src/main/res/values-is-rIS/strings.xml
@@ -185,4 +185,5 @@
     <string name="public_backup_frequency_7d">7 dagar</string>
     <string name="public_backup_frequency_14d">14 dagar</string>
     <string name="public_backup_frequency_1m">1 mánuður</string>
+    <string name="automatic_backup">Sjálfvirk öryggisafrit</string>
 </resources>

--- a/uhabits-android/src/main/res/values-it-rIT/strings.xml
+++ b/uhabits-android/src/main/res/values-it-rIT/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 giorni</string>
     <string name="public_backup_frequency_14d">14 giorni</string>
     <string name="public_backup_frequency_1m">1 mese</string>
+    <string name="automatic_backup">Backup automatico</string>
 </resources>

--- a/uhabits-android/src/main/res/values-iw-rIL/strings.xml
+++ b/uhabits-android/src/main/res/values-iw-rIL/strings.xml
@@ -245,4 +245,5 @@
     <string name="public_backup_frequency_7d">7 ימים</string>
     <string name="public_backup_frequency_14d">14 יום</string>
     <string name="public_backup_frequency_1m">חודש</string>
+    <string name="automatic_backup">גיבוי אוטומטי</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ja-rJP/strings.xml
+++ b/uhabits-android/src/main/res/values-ja-rJP/strings.xml
@@ -227,4 +227,5 @@
     <string name="public_backup_frequency_7d">7日</string>
     <string name="public_backup_frequency_14d">14日</string>
     <string name="public_backup_frequency_1m">1か月</string>
+    <string name="automatic_backup">自動バックアップ</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ka-rGE/strings.xml
+++ b/uhabits-android/src/main/res/values-ka-rGE/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 დღე</string>
     <string name="public_backup_frequency_14d">14 დღე</string>
     <string name="public_backup_frequency_1m">1 თვე</string>
+    <string name="automatic_backup">ავტომატური სარეზერვო</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ko-rKR/strings.xml
+++ b/uhabits-android/src/main/res/values-ko-rKR/strings.xml
@@ -227,4 +227,5 @@
     <string name="public_backup_frequency_7d">7 일</string>
     <string name="public_backup_frequency_14d">14 일</string>
     <string name="public_backup_frequency_1m">1 개월</string>
+    <string name="automatic_backup">자동 백업</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ml-rIN/strings.xml
+++ b/uhabits-android/src/main/res/values-ml-rIN/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 ദിവസം</string>
     <string name="public_backup_frequency_14d">14 ദിവസം</string>
     <string name="public_backup_frequency_1m">1 മാസം</string>
+    <string name="automatic_backup">യാന്ത്രിക ബാക്കപ്പ്</string>
 </resources>

--- a/uhabits-android/src/main/res/values-nl-rNL/strings.xml
+++ b/uhabits-android/src/main/res/values-nl-rNL/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 dagen</string>
     <string name="public_backup_frequency_14d">14 dagen</string>
     <string name="public_backup_frequency_1m">1 maand</string>
+    <string name="automatic_backup">Automatische back -up</string>
 </resources>

--- a/uhabits-android/src/main/res/values-no-rNO/strings.xml
+++ b/uhabits-android/src/main/res/values-no-rNO/strings.xml
@@ -151,4 +151,5 @@
     <string name="public_backup_frequency_7d">7 dager</string>
     <string name="public_backup_frequency_14d">14 dager</string>
     <string name="public_backup_frequency_1m">1 måned</string>
+    <string name="automatic_backup">Automatisk sikkerhetskopi</string>
 </resources>

--- a/uhabits-android/src/main/res/values-pl-rPL/strings.xml
+++ b/uhabits-android/src/main/res/values-pl-rPL/strings.xml
@@ -245,4 +245,5 @@
     <string name="public_backup_frequency_7d">7 dni</string>
     <string name="public_backup_frequency_14d">14 dni</string>
     <string name="public_backup_frequency_1m">1 miesiąc</string>
+    <string name="automatic_backup">Automatyczna kopia zapasowa</string>
 </resources>

--- a/uhabits-android/src/main/res/values-pt-rBR/strings.xml
+++ b/uhabits-android/src/main/res/values-pt-rBR/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 dias</string>
     <string name="public_backup_frequency_14d">14 dias</string>
     <string name="public_backup_frequency_1m">1 mês</string>
+    <string name="automatic_backup">Backup automático</string>
 </resources>

--- a/uhabits-android/src/main/res/values-pt-rPT/strings.xml
+++ b/uhabits-android/src/main/res/values-pt-rPT/strings.xml
@@ -193,4 +193,5 @@
     <string name="public_backup_frequency_7d">7 dias</string>
     <string name="public_backup_frequency_14d">14 dias</string>
     <string name="public_backup_frequency_1m">1 mês</string>
+    <string name="automatic_backup">Backup automático</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ro-rRO/strings.xml
+++ b/uhabits-android/src/main/res/values-ro-rRO/strings.xml
@@ -208,4 +208,5 @@
     <string name="public_backup_frequency_7d">7 zile</string>
     <string name="public_backup_frequency_14d">14 zile</string>
     <string name="public_backup_frequency_1m">1 lună</string>
+    <string name="automatic_backup">Backup automat</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ru-rRU/strings.xml
+++ b/uhabits-android/src/main/res/values-ru-rRU/strings.xml
@@ -244,4 +244,5 @@
     <string name="activity_not_found">Не найдено приложения для обработки данного действия</string>
     <string name="pref_midnight_delay_title">Продлить день на несколько часов после полуночи</string>
     <string name="pref_midnight_delay_description">Подождать до 3:00 перед показом нового дня. Полезно, если вы обычно ложитесь спать после полуночи. Требуется перезапуск приложения.</string>
+    <string name="automatic_backup">Автоматическая резервная копия</string>
 </resources>

--- a/uhabits-android/src/main/res/values-sk-rSK/strings.xml
+++ b/uhabits-android/src/main/res/values-sk-rSK/strings.xml
@@ -245,4 +245,5 @@
     <string name="public_backup_frequency_7d">7 dní</string>
     <string name="public_backup_frequency_14d">14 dní</string>
     <string name="public_backup_frequency_1m">1 mesiac</string>
+    <string name="automatic_backup">Automatická záloha</string>
 </resources>

--- a/uhabits-android/src/main/res/values-sl-rSI/strings.xml
+++ b/uhabits-android/src/main/res/values-sl-rSI/strings.xml
@@ -245,4 +245,5 @@
     <string name="public_backup_frequency_7d">7 dni</string>
     <string name="public_backup_frequency_14d">14 dni</string>
     <string name="public_backup_frequency_1m">1 mesec</string>
+    <string name="automatic_backup">Samodejno varnostno kopijo</string>
 </resources>

--- a/uhabits-android/src/main/res/values-sr-rCS/strings.xml
+++ b/uhabits-android/src/main/res/values-sr-rCS/strings.xml
@@ -232,4 +232,5 @@
     <string name="public_backup_frequency_7d">7 дана</string>
     <string name="public_backup_frequency_14d">14 дана</string>
     <string name="public_backup_frequency_1m">1 месец</string>
+    <string name="automatic_backup">Аутоматска резервна копија</string>
 </resources>

--- a/uhabits-android/src/main/res/values-sr-rSP/strings.xml
+++ b/uhabits-android/src/main/res/values-sr-rSP/strings.xml
@@ -239,4 +239,5 @@
     <string name="public_backup_frequency_7d">7 дана</string>
     <string name="public_backup_frequency_14d">14 дана</string>
     <string name="public_backup_frequency_1m">1 месец</string>
+    <string name="automatic_backup">Аутоматска резервна копија</string>
 </resources>

--- a/uhabits-android/src/main/res/values-sv-rSE/strings.xml
+++ b/uhabits-android/src/main/res/values-sv-rSE/strings.xml
@@ -242,4 +242,5 @@
     <string name="public_backup_frequency_7d">7 dagar</string>
     <string name="public_backup_frequency_14d">14 dagar</string>
     <string name="public_backup_frequency_1m">1 månad</string>
+    <string name="automatic_backup">Automatisk säkerhetskopiering</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ta-rIN/strings.xml
+++ b/uhabits-android/src/main/res/values-ta-rIN/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 நாட்கள்</string>
     <string name="public_backup_frequency_14d">14 நாட்கள்</string>
     <string name="public_backup_frequency_1m">1 மாதம்</string>
+    <string name="automatic_backup">தானியங்கி காப்புப்பிரதி</string>
 </resources>

--- a/uhabits-android/src/main/res/values-te-rIN/strings.xml
+++ b/uhabits-android/src/main/res/values-te-rIN/strings.xml
@@ -67,4 +67,5 @@
     <string name="public_backup_frequency_7d">7 రోజులు</string>
     <string name="public_backup_frequency_14d">14 రోజులు</string>
     <string name="public_backup_frequency_1m">1 నెల</string>
+    <string name="automatic_backup">ఆటోమేటిక్ బ్యాకప్</string>
 </resources>

--- a/uhabits-android/src/main/res/values-tr-rTR/strings.xml
+++ b/uhabits-android/src/main/res/values-tr-rTR/strings.xml
@@ -233,4 +233,5 @@
     <string name="public_backup_frequency_7d">7 gün</string>
     <string name="public_backup_frequency_14d">14 gün</string>
     <string name="public_backup_frequency_1m">1 ay</string>
+    <string name="automatic_backup">Otomatik yedekleme</string>
 </resources>

--- a/uhabits-android/src/main/res/values-ug-rCN/strings.xml
+++ b/uhabits-android/src/main/res/values-ug-rCN/strings.xml
@@ -43,4 +43,5 @@
     <string name="public_backup_frequency_7d">7 كۈن</string>
     <string name="public_backup_frequency_14d">14 كۈن</string>
     <string name="public_backup_frequency_1m">1 ئاي</string>
+    <string name="automatic_backup">ئاپتوماتىك زاپاسلاش</string>
 </resources>

--- a/uhabits-android/src/main/res/values-uk-rUA/strings.xml
+++ b/uhabits-android/src/main/res/values-uk-rUA/strings.xml
@@ -254,4 +254,5 @@
     <string name="public_backup_frequency_7d">7 днів</string>
     <string name="public_backup_frequency_14d">14 днів</string>
     <string name="public_backup_frequency_1m">1 місяць</string>
+    <string name="automatic_backup">Автоматичне резервне копіювання</string>
 </resources>

--- a/uhabits-android/src/main/res/values-vi-rVN/strings.xml
+++ b/uhabits-android/src/main/res/values-vi-rVN/strings.xml
@@ -227,4 +227,5 @@
     <string name="public_backup_frequency_7d">7 ngày</string>
     <string name="public_backup_frequency_14d">14 ngày</string>
     <string name="public_backup_frequency_1m">1 tháng</string>
+    <string name="automatic_backup">Sao lưu tự động</string>
 </resources>

--- a/uhabits-android/src/main/res/values-zh-rCN/strings.xml
+++ b/uhabits-android/src/main/res/values-zh-rCN/strings.xml
@@ -228,4 +228,5 @@
     <string name="public_backup_frequency_7d">7天</string>
     <string name="public_backup_frequency_14d">14天</string>
     <string name="public_backup_frequency_1m">1个月</string>
+    <string name="automatic_backup">自动备份</string>
 </resources>

--- a/uhabits-android/src/main/res/values-zh-rTW/strings.xml
+++ b/uhabits-android/src/main/res/values-zh-rTW/strings.xml
@@ -231,4 +231,5 @@
     <string name="public_backup_frequency_7d">7天</string>
     <string name="public_backup_frequency_14d">14天</string>
     <string name="public_backup_frequency_1m">1個月</string>
+    <string name="automatic_backup">自動備份</string>
 </resources>


### PR DESCRIPTION
## Summary
- add "automatic backup" translations to all localization files

## Testing
- `JAVA_HOME=/opt/jdk-17.0.8+7 ./gradlew uhabits-core:test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68a2d86c9fec832499a912fc5bdf9b5e